### PR TITLE
Unauthorized issue fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -396,7 +396,7 @@ module.exports = class Coins {
      * @returns {Number} The `nonce` value.
      */
     _getNonce() {
-        return new Date().getTime() * 1e13;
+        return new Date().getTime() * 1e126;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "wrapper"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (https://ionicabizau.net)",
+  "contributors": [
+    "Jeff Paredes <imjeffparedes@gmail.com> (https://www.linkedin.com/in/imjeffparedes)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/coins-ph/issues"


### PR DESCRIPTION
### Unauthorized issue fixe #18  

Coins API is denying the request due to nonce is too low.

Using nonce 
`new Date().getTime() * 1e13`

Body Response:
```
{ errors:
   { non_field_errors:
      'NONCE is too low.  Last value \'1538020576195000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\'' },
  meta: { error_codes: [ 'unauthorized' ] } }
```


