### PR TITLE
Fix 404 Page Not Found #22

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -459,7 +459,7 @@ module.exports = class Coins {
           , responseField = options.responseField || _url
           , version = options.version || "d/api"
           , qs = querystring.stringify(params)
-          , url = this.host + version + "/" + _url + "/" + (qs ? "?" + qs : "")
+          , url = this.host + version + "/" + _url + (qs ? "?" + qs : "")
           , signed = this._signRequest(url, data)
           ;
 


### PR DESCRIPTION
### Fixes for #22 
Fixed coins api returning 404 Page Not Found due to trailing slash at the end of url.
### Important! 
Use full sell order id!
Sample full sell order id: **0dbf5b202ae5407fbc727406d1fb10f1**