### PR TITLE
Added trailing slash to fix access sig error.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -459,7 +459,7 @@ module.exports = class Coins {
           , responseField = options.responseField || _url
           , version = options.version || "d/api"
           , qs = querystring.stringify(params)
-          , url = this.host + version + "/" + _url + (qs ? "?" + qs : "")
+          , url = this.host + version + "/" + _url + "/" + (qs ? "?" + qs : "")
           , signed = this._signRequest(url, data)
           ;
 


### PR DESCRIPTION
Either request or their web server auto-completes the URL to add a trailing slash when calculating the ACCESS_SIGNATURE resulting in different results for the access sig. This can be easily fixed by simply adding a trailing slash by default.