### PR TITLE
Increase nonce size to support HMAC requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -396,7 +396,7 @@ module.exports = class Coins {
      * @returns {Number} The `nonce` value.
      */
     _getNonce() {
-        return new Date().getTime() * 1e126;
+        return new Date().getTime() * 1e250;
     }
 
     /**


### PR DESCRIPTION
To support the HMAC(Key + Nonce) encryption header, the nonce now must be >= 1e250. This is not documented on their documentation page, but you will get a HTTP 401 and an error with no message property if you dont update this nonce value.

EDIT:
Provided a working example demo :)
```js
const Coins = require("coins-ph");
const Client = new Coins({
    key: process.env.COINS_PW_KEY
  , secret: process.env.COINS_PW_SECRET
});

Client._getNonce = () => Date.now() * 1e250;
Client.cryptoAccounts({}, (err, data) => console.log(err || data));
```