### PR TITLE
Fix incorrect documentation link for params  of convertFunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Convert funds between a user's accounts
 
 #### Params
 
-- **Object** `data`: The data object (documented [here](https://coins.readme.io/docs/crypto-exchanges)).
+- **Object** `data`: The data object (documented [here](https://coins.readme.io/docs/crypto-exchange)).
 - **Function** `cb`: The callback function.
 
 ### `cryptoExchanges(params, cb)`


### PR DESCRIPTION
`convertFunds` uses POST

In coins.ph docs:
`https://coins.readme.io/docs/crypto-exchanges` is for GET
`https://coins.readme.io/docs/crypto-exchange` is for POST